### PR TITLE
[codex] Style Feishu issue notifications as cards

### DIFF
--- a/.github/workflows/sync-issue-to-feishu.yml
+++ b/.github/workflows/sync-issue-to-feishu.yml
@@ -38,49 +38,135 @@ jobs:
           const issue = event.issue;
           const repository = event.repository;
           const repoName = repository.full_name;
-          const labels = issue.labels.map((label) => label.name).join(', ') || 'none';
-          const body = issue.body || '';
-          const bodyPreview =
-            body
+
+          const normalizeText = (value) =>
+            String(value || '')
               .replace(/\r\n/g, '\n')
               .replace(/\n{3,}/g, '\n\n')
-              .slice(0, 1600) || '(empty)';
+              .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g, '')
+              .trim();
+
+          const truncate = (value, maxLength) =>
+            value.length > maxLength
+              ? `${value.slice(0, maxLength - 1)}...`
+              : value;
+
+          const escapeLarkMarkdown = (value) =>
+            normalizeText(value)
+              .replace(/\\/g, '\\\\')
+              .replace(/`/g, '\\`')
+              .replace(/\*/g, '\\*')
+              .replace(/_/g, '\\_')
+              .replace(/\[/g, '\\[')
+              .replace(/\]/g, '\\]')
+              .replace(/\(/g, '\\(')
+              .replace(/\)/g, '\\)')
+              .replace(/~/g, '\\~')
+              .replace(/</g, '‹')
+              .replace(/>/g, '›');
+
+          const labelNames = issue.labels.map((label) => label.name);
+          const getIssueKind = (labels) => {
+            if (labels.includes('bug')) {
+              return 'bug';
+            }
+
+            if (labels.includes('enhancement')) {
+              return 'enhancement';
+            }
+
+            if (labels.includes('question')) {
+              return 'question';
+            }
+
+            return 'issue';
+          };
+          const issueKind = getIssueKind(labelNames);
+          const primaryLabel = labelNames[0] || issueKind;
+          const headerTemplateByKind = {
+            bug: 'red',
+            enhancement: 'green',
+            question: 'blue',
+            issue: 'blue',
+          };
+          const getLabelColor = (label) => ({
+            bug: 'red',
+            enhancement: 'green',
+            question: 'blue',
+          })[label] || 'neutral';
+          const headerTemplate = headerTemplateByKind[issueKind];
+          const labelTags =
+            labelNames
+              .map((label) => {
+                const color = getLabelColor(label);
+                return `<text_tag color='${color}'>${escapeLarkMarkdown(label)}</text_tag>`;
+              })
+              .join(' ') || "<font color='grey'>none</font>";
+          const body = issue.body || '';
+          const bodyPreview = truncate(escapeLarkMarkdown(body) || '(empty)', 1000);
+          const title = truncate(normalizeText(issue.title).replace(/\n/g, ' '), 100);
+          const createdAt = new Intl.DateTimeFormat('zh-CN', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+            timeZone: 'Asia/Shanghai',
+          })
+            .format(new Date(issue.created_at))
+            .replace(/\//g, '-');
 
           const payload = {
-            msg_type: 'post',
-            content: {
-              post: {
-                zh_cn: {
-                  title: `GitHub Issue #${issue.number}: ${issue.title}`,
-                  content: [
-                    [
-                      {
-                        tag: 'text',
-                        text: `Repository: ${repoName}\n`,
-                      },
-                    ],
-                    [
-                      {
-                        tag: 'text',
-                        text: `Author: ${issue.user.login} | Labels: ${labels}\n`,
-                      },
-                    ],
-                    [
-                      {
-                        tag: 'text',
-                        text: `Summary:\n${bodyPreview}\n`,
-                      },
-                    ],
-                    [
-                      {
-                        tag: 'a',
-                        text: 'Open issue',
-                        href: issue.html_url,
-                      },
-                    ],
-                  ],
+            msg_type: 'interactive',
+            card: {
+              config: {
+                enable_forward: true,
+                update_multi: true,
+              },
+              card_link: {
+                url: issue.html_url,
+              },
+              header: {
+                template: headerTemplate,
+                title: {
+                  tag: 'plain_text',
+                  content: `GitHub Issue #${issue.number}: ${title}`,
                 },
               },
+              elements: [
+                {
+                  tag: 'markdown',
+                  content: [
+                    `**Repository:** [${repoName}](${repository.html_url})`,
+                    `**Type:** ${escapeLarkMarkdown(primaryLabel)}`,
+                    `**Author:** ${escapeLarkMarkdown(issue.user.login)}`,
+                    `**Created:** ${createdAt} UTC+8`,
+                    `**Labels:** ${labelTags}`,
+                  ].join('\n'),
+                },
+                {
+                  tag: 'hr',
+                },
+                {
+                  tag: 'markdown',
+                  content: `**Summary**\n${bodyPreview}`,
+                },
+                {
+                  tag: 'action',
+                  actions: [
+                    {
+                      tag: 'button',
+                      text: {
+                        tag: 'plain_text',
+                        content: 'Open issue',
+                      },
+                      type: 'primary',
+                      url: issue.html_url,
+                    },
+                  ],
+                },
+              ],
             },
           };
 


### PR DESCRIPTION
## Summary

- Switch the Feishu issue notification payload from `post` rich text to an `interactive` card.
- Add color-coded card headers by issue label: `bug` red, `enhancement` green, `question` blue, fallback blue.
- Add structured card fields, label tags, a card-level issue link, and an `Open issue` button.
- Sanitize untrusted issue body text so raw strings such as `<at id=all>` do not become Feishu mentions.

## Validation

- `ruby -e 'require "yaml"; data = YAML.load_file(".github/workflows/sync-issue-to-feishu.yml"); abort("missing jobs") unless data["jobs"]; puts "workflow yaml ok"'`
- `git diff --check -- .github/workflows/sync-issue-to-feishu.yml`
- Extracted and ran the workflow Node payload builder against a fixture issue; verified `msg_type: interactive`, red bug header, `Open issue` button URL, and no raw `<at id=all>` in the sanitized summary.
- Sent one style smoke payload through the configured Feishu webhook; Feishu returned `code: 0` / `success`.
- Verified in `Mavis Agent新框架讨论` with `lark-cli`: message `om_x100b6d7472b4c4a8b3b490bfb5f6db7`, `msg_type: interactive`, sender `app`.
