### PR TITLE
fix(issue-template): let users attach screenshots to bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -99,9 +99,23 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Logs, screenshots, or crash reports / 日志、截图或崩溃信息
-      description: Please remove secrets, tokens, API keys, private paths, and private code.
+      label: Logs or crash report / 日志或崩溃信息
+      description: |
+        Paste the relevant log lines or stack trace here. They will be rendered as a code block.
+        Please remove secrets, tokens, API keys, private paths, and private code.
+        粘贴相关日志或堆栈，会自动按代码块渲染。
+        提交前请移除 Secret、Token、API Key、私有路径和私有代码。
       render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / 截图
+      description: |
+        Drag and drop screenshots here, or paste them directly. (GitHub disables image upload inside the Logs field above, so screenshots go here.)
+        把截图直接拖到这里，或者粘贴。（上面「日志」字段是代码块，GitHub 不允许在里面贴图，所以截图请放这里。）
     validations:
       required: false
 


### PR DESCRIPTION
## What's broken

Issue #53 (and similar reports) — users dragging a screenshot into the bug-report form see "upload failed" and give up.

## Root cause

The combined **Logs, screenshots, or crash reports** textarea uses [`render: shell`](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#render). GitHub's issue forms disable image upload (drag-drop / paste) inside any render-typed textarea — the content is locked into a fenced code block. So screenshots never had a chance to upload.

Evidence — issue #53's body for that field is just an empty `````shell````` block.

## Fix

Split the single field in two:

- **Logs or crash report** — keeps `render: shell` so stack traces render as a code block.
- **Screenshots** — plain textarea so drag-drop / paste image upload works (matches how every other GitHub form lets users attach images).

Bilingual labels + description preserved; placeholder for the screenshots field explicitly tells users why this exists.

## Verified

- Parsed the updated YAML — 13 body items, all types valid, new `id=screenshots` slots between logs and the checklist.
- No effect on `02-feature-request.yml` / `03-question.yml` — they never used `render: shell`.

Closes #53.